### PR TITLE
Add AWS readme suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ dns:
   provider: "cloudflare"
   domain: "example.com"
   zone_id: "your-zone-id"
-  
+
   cloudflare:
     api_token: "your-cloudflare-api-token"
 
@@ -184,8 +184,43 @@ For a device named `web-server` in domain `example.com`:
 ### Route53 Setup
 
 1. Ensure you have AWS credentials configured (via AWS CLI, environment variables, or IAM roles)
-2. Get the Hosted Zone ID from the Route53 console
-3. Ensure your AWS credentials have permissions to manage DNS records in the zone
+
+    a. If using AWS environment variables the AWS sdk looks for `AWS_ACCESS_KEY_ID` and  `AWS_SECRET_ACCESS_KEY`.
+
+1. Get the Hosted Zone ID from the Route53 console
+
+1. Ensure your AWS credentials have permissions to manage DNS records in the zone
+
+    ```json
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowDNSZoneAccess",
+                "Effect": "Allow",
+                "Action": [
+                    "route53:GetChange",
+                    "route53:GetHostedZone",
+                    "route53:ChangeResourceRecordSets",
+                    "route53:ListResourceRecordSets"
+                ],
+                "Resource": [
+                    "arn:aws:route53:::change/*",
+                    "arn:aws:route53:::hostedzone/<your-zone-id>"
+                ]
+            },
+            {
+                "Sid": "ListZones",
+                "Effect": "Allow",
+                "Action": [
+                    "route53:ListHostedZonesByName",
+                    "route53:ListHostedZones"
+                ],
+                "Resource": "*"
+            }
+        ]
+    }
+    ```
 
 ## Tag Filtering
 


### PR DESCRIPTION
This adds some details around using this tool with route53.

Includes suggestions around environment variables and IAM Policies necessary.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add AWS Route53 setup details, including environment variables and IAM policy, to `README.md`.
> 
>   - **AWS Route53 Setup**:
>     - Adds details on using AWS environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
>     - Provides example IAM policy for managing DNS records in Route53.
>   - **Misc**:
>     - Minor whitespace change in `README.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Fdnsscale&utm_source=github&utm_medium=referral)<sup> for 8830e8daf4966d50a31b07ce72fe8cfb52c96bae. You can [customize](https://app.ellipsis.dev/jaxxstorm/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->